### PR TITLE
fix: js_token to prevent direct submission

### DIFF
--- a/pages/contact.html
+++ b/pages/contact.html
@@ -8,7 +8,7 @@
     <script
       data-cfasync="false"
       type="text/javascript"
-      src="../form-submission-handler.js"
+      src="../submit.js"
     ></script>
 
     <link rel="stylesheet" href="../styles/styles.css" />
@@ -62,11 +62,12 @@
           </div>
 
           <form
-            action="https://script.google.com/macros/s/AKfycbwyDmUlC6buzsRSGoXTGVmKql00mE4rDEmMKDI3yhrI3Kt1ET-l6isx-j46ewve-5o0/exec"
+            action="https://script.google.com/macros/s/AKfycbyklYEdUErgmpaq222KDMXbj4eiAepJ0Y0-x64pLkSuNVBFEnETs3TznK1FlJ2pqR3M/exec"
             method="POST"
             class="gform inquiry__form"
           >
           <input type="text" name="honeypot" style="display:none">
+          <input type="hidden" name="js_token" id="js_token" value="">
             <div class="form__item">
               <label for="name" class="block">Full Name</label>
               <input class="input" type="text" name="name" id="name" required />

--- a/submit.js
+++ b/submit.js
@@ -4,6 +4,11 @@
     var elements = form.elements
     var honeypot
 
+    const jsToken = document.getElementById('js_token')
+    jsToken.value = btoa(Date.now() + '-' + Math.random().toString(36).substring(2))
+
+    
+
     var fields = Object.keys(elements)
       .filter(function (k) {
         if (elements[k].name === 'honeypot') {


### PR DESCRIPTION
Realized that the issue was that the URL was being hit directly and all of the JS was being bypassed.
- So, I added an invisible input that randomly generates a token and a corresponding change on the AppScript that checks for it. That way it is impossible for a bot to programmatically POST to the URL without filling out the form.