### PR TITLE
fix: favicon

### DIFF
--- a/images/favicon.svg
+++ b/images/favicon.svg
@@ -1,5 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="48" zoomAndPan="magnify" viewBox="0 0 36 36.000001" height="48" preserveAspectRatio="xMidYMid meet" version="1.0">
   <style>
+
+    :root {
+    stroke: #000000;
+    }
     @media (prefers-color-scheme: dark) {
         :root {
         stroke: #f5f5f3;


### PR DESCRIPTION
Realized the SVG was rendering weirdly and only showing a black stroked outline on the OG image. Added a solid black stroke on top to make it look more consistent with the dark-mode styling